### PR TITLE
Fix: axios 0.20.0 has critical security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@fullcalendar/daygrid": "^5.3.2",
     "@fullcalendar/interaction": "^5.3.1",
     "@fullcalendar/vue": "^5.3.1",
-    "axios": "^0.21.0",
+    "axios": "^0.21.1",
     "buefy": "^0.9.3",
     "core-js": "^3.6.5",
     "tiptap": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@fullcalendar/daygrid": "^5.3.2",
     "@fullcalendar/interaction": "^5.3.1",
     "@fullcalendar/vue": "^5.3.1",
-    "axios": "^0.20.0",
+    "axios": "^0.21.0",
     "buefy": "^0.9.3",
     "core-js": "^3.6.5",
     "tiptap": "^1.30.0",


### PR DESCRIPTION
## Overview

The used `axios` version `0.20.0` has a known critical security vulnerability for SSRF in **versions <0.21.1** and here's the [**Official PR #3410**](https://github.com/axios/axios/pull/3410).

Here's the vulnerability [**axios Server-Side Request Forgery (SSRF)**](https://security.snyk.io/vuln/SNYK-JS-AXIOS-1038255).

Also, the [**Official issue #3407**](https://github.com/axios/axios/issues/3407).

## Solution

Update `axios` to **version > 0.21.0**.